### PR TITLE
Discovery Plus, check for jq and warn if missing

### DIFF
--- a/DISCOVERY-PLUS-YTDLP/DISCOVERY_PLUS-YTDLP
+++ b/DISCOVERY-PLUS-YTDLP/DISCOVERY_PLUS-YTDLP
@@ -100,6 +100,10 @@ export TERM=xterm-256color
     printf '%*.*s \e[36m\e[1m%s\e[21m\e[0m %*.*s\n' 0 "$(((termwidth-2-${#1})/2))" "$padding" "$1" 0 "$(((termwidth-1-${#1})/2))" "$padding"
   }
 
+if ! hash jq; then
+  echo Could not find jq on path, exiting.
+  exit 1
+fi
 
 ## LET'S GET THE PARTY STARTED BY GRABBING SOME USER INPUT...
 clear


### PR DESCRIPTION
Hi, as I mentioned on reddit, if you don't have `jq` installed the script currently just finds 0 episodes. I think this is responsible for many of the people saying it doesn't work. i just added a check for `jq`, if it's not on the path it will now let the user know to install it.