### PR TITLE
Add option to use a log file to allow resuming downloads

### DIFF
--- a/DISCOVERY-PLUS-YTDLP/DISCOVERY_PLUS-YTDLP
+++ b/DISCOVERY-PLUS-YTDLP/DISCOVERY_PLUS-YTDLP
@@ -151,6 +151,20 @@ read -n 1 -s -r -p "`centerBLINK '_-Press Any Key to Continue-_'`"
 clear
 
 
+## LET'S ASK IF YOU WANT A LOG FILE
+clear
+centerCOLOR_ONE "OPTIONAL: Provide The FULL PATH For The Download Log File:"
+centerCOLOR_TWO "Ex: /STORAGE/DISCOVERY_PLUS/DISCOVERY_PLUS_LOG.txt"
+centerCOLOR_THREE "This will let you restart the script and skip already downloaded episodes"
+centerCOLOR_FOUR "Leave blank to disable."
+read -e -r -p "`printf "\e[35m\e[1m\nENTER PATH:\n\e[36m\e[1m>\e[21m\e[0m "`" LOG_FILE
+clear
+centerCOLOR_ONE "Download Log Path Entered:"
+centerCOLOR_TWO "$LOG_FILE" && sleep 1 && echo "" && echo ""
+read -n 1 -s -r -p "`centerBLINK '_-Press Any Key to Continue-_'`"
+clear
+
+
 ## CREATE A TMP DIRECTORY TO SAFELY WORK INSIDE OF..
 cd "$OUTPUTDIR" || exit
 TMPWORKDIR=$(echo "${URL_SLUG}_$((1 + $RANDOM % 10000))_TMPWORKDIR")
@@ -225,6 +239,7 @@ clear
       --no-warnings \
       --extractor-retries 10 \
       --hls-prefer-ffmpeg \
+      ${LOG_FILE:+--download-archive $LOG_FILE} \
       -o '%(series)s/Season %(season_number)s/%(series)s - S%(season_number)02dE%(episode_number)02d: %(title)s.%(ext)s' \
       "$EP_URL"
 

--- a/DISCOVERY-PLUS-YTDLP/DISCOVERY_PLUS-YTDLP
+++ b/DISCOVERY-PLUS-YTDLP/DISCOVERY_PLUS-YTDLP
@@ -220,7 +220,6 @@ SEASONS_SUM=$(echo "$SHOW_SEASON_COUNT" | wc -l)
 centerCOLOR_ONE "$SEASONS_SUM Seasons Found!" && sleep 1 && echo ""
 centerCOLOR_TWO "$EPISODE_COUNT Episodes Found!" && sleep 3 && echo "" && echo ""
 read -n 1 -s -r -p "`centerBLINK '_-Press Any Key to Begin Downloading The Episodes-_'`"
-clear
 
 
 ### Now We Sit Back and Have YT-DLP Download Every Episode We Found From Our TXT File
@@ -241,20 +240,31 @@ clear
       --hls-prefer-ffmpeg \
       ${LOG_FILE:+--download-archive $LOG_FILE} \
       -o '%(series)s/Season %(season_number)s/%(series)s - S%(season_number)02dE%(episode_number)02d: %(title)s.%(ext)s' \
-      "$EP_URL"
+      "$1"
 
   }
 
+## THE NUMBER OF DOWNLOADS TO RUN AT ONCE, MODIFY AS NEEDED
+## CURRENTLY THIS SCRIPT WILL CREATE 5 THREADS AT A TIME
+THREADS=5
 
-## READ LINES FROM EPISODE_URL_LIST AND PASS IT TO MULTI_THREAD FUNCTION
-while read -r EP_URL; do
-  centerBOLD "Downloading:"
-  centerBOLD_TWO "$EP_URL"
-  MULTI_THREAD &
-  ## THE NUMBER DIRRCTLY FOLLOWING "-ge" IS HOW MANY THREADS,MODIFY AS NEEDED
-  ## CURRENTLY THIS SCRIPT WILL CREATE 5 THREADS AT A TIME
-  [ "$( jobs | wc -l )" -ge 5 ] && wait
-done < "$EPISODE_URL_LIST"
+if ! hash parallel; then {
+  centerCOLOR_FOUR "GNU Parallel not available, falling back to shell jobs"
+  ## READ LINES FROM EPISODE_URL_LIST AND PASS IT TO MULTI_THREAD FUNCTION
+  while read -r EP_URL; do
+    centerBOLD "Downloading:"
+    centerBOLD_TWO "$EP_URL"
+    MULTI_THREAD $EP_URL &
+    [ "$( jobs | wc -l )" -ge $THREADS ] && wait
+  done < "$EPISODE_URL_LIST"
+}
+else {
+    export -f MULTI_THREAD
+    export COOKIE_FILE
+    export LOG_FILE
+    parallel --bar -P$THREADS MULTI_THREAD < "$EPISODE_URL_LIST"
+}
+fi
 wait
 clear
 


### PR DESCRIPTION
So this is what I originally set out to do. I asked if you could download specific seasons but I guess "The client doesn't know what they need" applies to me too because what I actually needed was to use a `yt-dlp`'s `--download-archive` option to record downloaded episodes and avoid re-downloading them (the show I want is over 20 seasons, 10+ episodes per season). I added a screen to prompt for a path to use for the log file, and as it says this can be left empty and it will act like before. I'm not sure if I used your color helpers correctly, I see you were putting all the text in the `-p` argument to `read`, but that would always put it all on one line for me. 

The second commit here is to use GNU Parallel if it is available. The reason for this is the the shell job based method launches 5 downloads, and doesn't launch anything else until all 5 finish. I first noticed this because if say 3/5 in the batch are already recorded as done, the 2 that are not will download on their own before the next 5 launch. But even outside of this edge case, there seems to be (at least on my connection) 2-5 minutes between the first and last download in a batch finishing which is wasted time. Parallel also adds some nice features such as a progress bar showing how many downloads are complete and how many are left. If it is not installed we fall back to the existing bash jobs method with a warning the parallel is not available. The only drawback if parallel is not colorful 😄. If you would prefer to keep using the existing threading, just leave out the second commit.